### PR TITLE
fix: consider zero when retry_count not present

### DIFF
--- a/lib/sidekiq/silent_retry/server_middleware.rb
+++ b/lib/sidekiq/silent_retry/server_middleware.rb
@@ -17,7 +17,7 @@ module Sidekiq
       private
 
       def should_warn?(job_payload)
-        job_payload["retry_count"] >= warn_after(job_payload)
+        (job_payload["retry_count"] || 0) >= warn_after(job_payload)
       end
 
       def warn_after(job_payload)

--- a/spec/sidekiq/silent_retry/server_middleware_spec.rb
+++ b/spec/sidekiq/silent_retry/server_middleware_spec.rb
@@ -10,12 +10,36 @@ RSpec.describe Sidekiq::SilentRetry::ServerMiddleware do
     -> { raise error_class, "some message" }
   end
   let(:job_payload) do
-    payload = {
+    {
+      "retry_count" => retry_count,
       "retry" => 2,
       "silent_retry" => silent_retry
     }
-    payload["retry_count"] = retry_count if retry_count
-    payload
+  end
+
+  context 'in the first failure' do
+    let(:job_payload) do
+      {
+        "retry" => 2,
+        "silent_retry" => silent_retry
+      }
+    end
+
+    context 'with silent retry enabled' do
+      let(:silent_retry) { true }
+
+      it 'raises the silent error' do
+        expect { subject }.to raise_error(Sidekiq::SilentRetry.silent_retry_error_class, "some message")
+      end
+    end
+
+    context 'with silent retry disabled' do
+      let(:silent_retry) { false }
+
+      it 'raises the error' do
+        expect { subject }.to raise_error(StandardError, "some message")
+      end
+    end
   end
 
   context "when silent retry is off" do

--- a/spec/sidekiq/silent_retry/server_middleware_spec.rb
+++ b/spec/sidekiq/silent_retry/server_middleware_spec.rb
@@ -10,11 +10,12 @@ RSpec.describe Sidekiq::SilentRetry::ServerMiddleware do
     -> { raise error_class, "some message" }
   end
   let(:job_payload) do
-    {
-      "retry_count" => retry_count,
+    payload = {
       "retry" => 2,
       "silent_retry" => silent_retry
     }
+    payload["retry_count"] = retry_count if retry_count
+    payload
   end
 
   context "when silent retry is off" do


### PR DESCRIPTION
## Fix Explanation

We're having some errors in the first failure of jobs with silent active because the `job_payload` won't have the `retry_count` key if there were no retries. This is happening because Sidekiq sets the `retry_count` key on the `job_payload` to zero only after the first failure of the job: [see source](https://github.com/sidekiq/sidekiq/blob/f2858e175efd57cffc3db50a19dd315e37b08668/lib/sidekiq/job_retry.rb#L163). As a side note, observe that the first try doesn't count as a retry in the `retry_count`, so, the way it's implemented today, the `warn_after` means warn after # of retries and not # of tries (first try + retry_count) in general.

fix: #6 