### PR TITLE
fix: correct Gemfile.lock to create a new release

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sidekiq-silent-retry (0.2.0)
+    sidekiq-silent-retry (0.3.0)
       sidekiq (~> 6.0)
 
 GEM


### PR DESCRIPTION
Fixes a problem in the CI. I've just ran `bundle install` on it and this was what the Gemfile.lock changed.