### PR TITLE
Bump rack to fix security vulnerabilities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in sidekiq-silent-retry.gemspec
 gemspec
 
-gem "rack", ">= 2.2.13", "< 3"
+gem "rack", ">= 2.2.22"
 
 gem "rake", "~> 13.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sidekiq-silent-retry (0.3.2)
+    sidekiq-silent-retry (0.3.3)
       sidekiq (>= 6.0)
 
 GEM
@@ -19,7 +19,7 @@ GEM
       ast (~> 2.4.1)
       racc
     racc (1.8.0)
-    rack (2.2.20)
+    rack (3.2.6)
     rainbow (3.1.1)
     rake (13.2.1)
     redis-client (0.24.0)
@@ -66,11 +66,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  rack (>= 2.2.13, < 3)
+  rack (>= 2.2.22)
   rake (~> 13.0)
   rspec (~> 3.0)
   rubocop (~> 1.21)
   sidekiq-silent-retry!
 
 BUNDLED WITH
-   2.6.6
+  4.0.3

--- a/lib/sidekiq/silent_retry/version.rb
+++ b/lib/sidekiq/silent_retry/version.rb
@@ -2,6 +2,6 @@
 
 module Sidekiq
   module SilentRetry
-    VERSION = "0.3.2"
+    VERSION = "0.3.3"
   end
 end


### PR DESCRIPTION
## Summary
- Bumps `rack` from 2.2.20 to 3.2.6 to resolve XSS and directory traversal vulnerabilities in `Rack::Directory`
- Removes the `< 3` upper bound on rack
- Bumps gem version from 0.3.2 to 0.3.3

## Test plan
- [ ] Verify tests pass with rack 3.x
- [ ] Confirm sidekiq integration still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)